### PR TITLE
Scroll on ballot item selection

### DIFF
--- a/src/locality.page/index.js
+++ b/src/locality.page/index.js
@@ -14,7 +14,7 @@ angular.module('locality.page', [])
     }
   });
 
-function LocalityController ($interpolate, $rootScope, $route) {
+function LocalityController ($anchorScroll, $interpolate, $rootScope, $route) {
   var ctrl = this;
   ctrl.ballot_item = {};
 
@@ -31,6 +31,7 @@ function LocalityController ($interpolate, $rootScope, $route) {
   // Listen to route changes to update the ballot_item detail
   $rootScope.$on('$routeUpdate', function (event, next) {
     ctrl.ballot_item = findBallotItem(next.params);
+    $anchorScroll('ballot-content');
   });
 
   // Sort ballot_items into offices/referendums

--- a/src/locality.page/locality.html
+++ b/src/locality.page/locality.html
@@ -4,7 +4,7 @@
     <span>Next election: {{ $ctrl.ballot.date | date:'MMMM d, yyyy' }}</span>
   </div>
 </div>
-<div class="row">
+<div id="ballot-content" class="row">
   <div class="col-sm-8 col-sm-push-4">
     <ballot-item-detail ballot-item="$ctrl.ballot_item"></ballot-item-detail>
   </div>


### PR DESCRIPTION
On the locality page, when you select a ballot item on mobile, the screen jumps all over the place. Scroll to the top to avoid a jarring experience.